### PR TITLE
MNT: Increment lume-epics version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.7
   - jupyter_bokeh
-  - lume-epics==0.6
+  - lume-epics==0.7
   - lume-model==0.8
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.7
   - jupyter_bokeh
-  - lume-epics==0.7
+  - lume-epics==0.8
   - lume-model==0.8
   - pip
   - pip:


### PR DESCRIPTION
Updates lume-epics to v0.7, which implements a fix in the render-from-template command. Previously, the prefix and protocol arguments were switched leading to non-functional controllers and incorrect prefixes for the process variables.